### PR TITLE
Update base0 colors in Xcode Dark and Light templates

### DIFF
--- a/templates/_xcodedark_colors.colortemplate
+++ b/templates/_xcodedark_colors.colortemplate
@@ -1,4 +1,4 @@
-Color: base0        #292a30 ~
+Color: base0        #000000 ~
 Color: base1        #2f3037 ~
 Color: base2        #393b44 ~
 Color: base3        #414453 ~

--- a/templates/_xcodelight_colors.colortemplate
+++ b/templates/_xcodelight_colors.colortemplate
@@ -1,4 +1,4 @@
-Color: base0       #ffffff ~
+Color: base0       #eeeeee ~
 Color: base1       #f4f4f4 ~
 Color: base2       #e5e5e5 ~
 Color: base3       #cdcdcd ~


### PR DESCRIPTION
## Summary
- Adjusts the base0 color in the Xcode Dark and Light color templates for improved background consistency

## Changes

### Color Template Updates
- **Xcode Dark Template**: Changed base0 color from `#292a30` to pure black `#000000` for a deeper dark background
- **Xcode Light Template**: Changed base0 color from pure white `#ffffff` to a softer light gray `#eeeeee` for a less harsh background

## Test plan
- [x] Verify that the dark theme background appears fully black
- [x] Verify that the light theme background appears as a soft light gray
- [x] Confirm no other colors or template elements were affected by the change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/58e4b579-31a0-4bc4-908e-6ff80fb4ce32