### PR TITLE
Refine base0 background colors and cursor highlights in Xcode themes for improved consistency

### DIFF
--- a/colors/xcode.vim
+++ b/colors/xcode.vim
@@ -411,7 +411,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi EndOfBuffer guifg=#e8e9ec guibg=#e8e9ec gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
-  hi LineNr guifg=#cdcdcd guibg=#e8e9ec gui=NONE cterm=NONE
+  hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi MatchWord guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcode.vim
+++ b/colors/xcode.vim
@@ -404,22 +404,22 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcode_dim_punctuation')
     let g:xcode_dim_punctuation = 1
   endif
-  hi Normal guifg=#262626 guibg=#eeeeee gui=NONE cterm=NONE
-  hi Cursor guifg=#eeeeee guibg=#262626 gui=NONE cterm=NONE
+  hi Normal guifg=#262626 guibg=#e8e9ec gui=NONE cterm=NONE
+  hi Cursor guifg=#e8e9ec guibg=#262626 gui=NONE cterm=NONE
   hi None guifg=#262626 guibg=NONE gui=NONE cterm=NONE
   hi CursorLineNr guifg=#262626 guibg=#ecf5ff gui=NONE cterm=NONE
-  hi EndOfBuffer guifg=#eeeeee guibg=#eeeeee gui=NONE cterm=NONE
+  hi EndOfBuffer guifg=#e8e9ec guibg=#e8e9ec gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
-  hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
+  hi LineNr guifg=#cdcdcd guibg=#e8e9ec gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
-  hi MatchWord guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi MatchWord guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Signify guifg=#69a7fc guibg=NONE gui=NONE cterm=NONE
   hi Ignore guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Pmenu guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi PmenuSbar guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi PmenuSel guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi PmenuSel guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi PmenuThumb guifg=#e5e5e5 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi ErrorMsg guifg=#d12f1b guibg=NONE gui=NONE cterm=NONE
   hi ModeMsg guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
@@ -429,11 +429,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi ColorColumn guifg=NONE guibg=#f4f4f4 gui=NONE cterm=NONE
   hi CursorColumn guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
   hi CursorLine guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
-  hi QuickFixLine guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi QuickFixLine guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi StatusLine guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi StatusLineNC guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi VertSplit guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi WildMenu guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi WildMenu guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi IncSearch guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi Search guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi Visual guifg=NONE guibg=#b4d8fd gui=NONE cterm=NONE
@@ -442,7 +442,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi DiffDelete guifg=NONE guibg=#fef0f1 gui=NONE cterm=NONE
   hi DiffText guifg=NONE guibg=#fdfae6 gui=NONE cterm=NONE
   hi Comment guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
-  hi Error guifg=#eeeeee guibg=#d12f1b gui=NONE cterm=NONE
+  hi Error guifg=#e8e9ec guibg=#d12f1b gui=NONE cterm=NONE
   hi PreProc guifg=#78492a guibg=NONE gui=NONE cterm=NONE
   hi Special guifg=#23575c guibg=NONE gui=NONE cterm=NONE
   hi Statement guifg=#ad3da4 guibg=NONE gui=bold cterm=bold
@@ -706,7 +706,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if g:xcode_match_paren_style
     hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   else
-    hi MatchParen guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+    hi MatchParen guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   endif
   if g:xcode_dim_punctuation
     hi Delimiter guifg=#5c6873 guibg=NONE gui=NONE cterm=NONE
@@ -1422,7 +1422,7 @@ endif
 " Term colors: base5      red  light_teal   orange
 " Term colors: light_blue pink light_purple base7
 " Background: light
-" Color: base0       #eeeeee ~
+" Color: base0       #e8e9ec ~
 " Color: base1       #f4f4f4 ~
 " Color: base2       #e5e5e5 ~
 " Color: base3       #cdcdcd ~

--- a/colors/xcode.vim
+++ b/colors/xcode.vim
@@ -53,11 +53,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     endif
     " support for folke/flash.nvim
     hi FlashLabel guifg=#1f1f24 guibg=#ff7ab2 gui=bold cterm=bold
-    hi Normal guifg=#dfdfe0 guibg=#292a30 gui=NONE cterm=NONE
-    hi Cursor guifg=#292a30 guibg=#dfdfe0 gui=NONE cterm=NONE
+    hi Normal guifg=#dfdfe0 guibg=#000000 gui=NONE cterm=NONE
+    hi Cursor guifg=#000000 guibg=#dfdfe0 gui=NONE cterm=NONE
     hi None guifg=#dfdfe0 guibg=NONE gui=NONE cterm=NONE
     hi CursorLineNr guifg=#dfdfe0 guibg=#2f3037 gui=NONE cterm=NONE
-    hi EndOfBuffer guifg=#292a30 guibg=#292a30 gui=NONE cterm=NONE
+    hi EndOfBuffer guifg=#000000 guibg=#000000 gui=NONE cterm=NONE
     hi FoldColumn guifg=#53606e guibg=NONE gui=NONE cterm=NONE
     hi Folded guifg=#53606e guibg=#393b44 gui=NONE cterm=NONE
     hi LineNr guifg=#53606e guibg=NONE gui=NONE cterm=NONE
@@ -82,7 +82,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     hi StatusLineNC guifg=#7f8c98 guibg=#393b44 gui=NONE cterm=NONE
     hi VertSplit guifg=#393b44 guibg=#393b44 gui=NONE cterm=NONE
     hi WildMenu guifg=#dfdfe0 guibg=#0f5bca gui=NONE cterm=NONE
-    hi IncSearch guifg=#292a30 guibg=#fef937 gui=NONE cterm=NONE
+    hi IncSearch guifg=#000000 guibg=#fef937 gui=NONE cterm=NONE
     hi Search guifg=#dfdfe0 guibg=#414453 gui=NONE cterm=NONE
     hi Visual guifg=NONE guibg=#414453 gui=NONE cterm=NONE
     hi DiffAdd guifg=#acf2e4 guibg=#243330 gui=NONE cterm=NONE
@@ -90,7 +90,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     hi DiffDelete guifg=#ff8170 guibg=#3b2d2b gui=NONE cterm=NONE
     hi DiffText guifg=#ffa14f guibg=#382e27 gui=NONE cterm=NONE
     hi Comment guifg=#7f8c98 guibg=NONE gui=NONE cterm=NONE
-    hi Error guifg=#292a30 guibg=#ff8170 gui=NONE cterm=NONE
+    hi Error guifg=#000000 guibg=#ff8170 gui=NONE cterm=NONE
     hi PreProc guifg=#ffa14f guibg=NONE gui=NONE cterm=NONE
     hi Special guifg=#78c2b3 guibg=NONE gui=NONE cterm=NONE
     hi Statement guifg=#ff7ab2 guibg=NONE gui=bold cterm=bold
@@ -352,7 +352,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
       hi LibraryIdent guifg=#b281eb guibg=NONE gui=NONE cterm=NONE
     endif
     if g:xcode_match_paren_style
-      hi MatchParen guifg=#292a30 guibg=#fef937 gui=NONE cterm=NONE
+      hi MatchParen guifg=#000000 guibg=#fef937 gui=NONE cterm=NONE
     else
       hi MatchParen guifg=#dfdfe0 guibg=#0f5bca gui=NONE cterm=NONE
     endif
@@ -404,22 +404,22 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if !exists('g:xcode_dim_punctuation')
     let g:xcode_dim_punctuation = 1
   endif
-  hi Normal guifg=#262626 guibg=#ffffff gui=NONE cterm=NONE
-  hi Cursor guifg=#ffffff guibg=#262626 gui=NONE cterm=NONE
+  hi Normal guifg=#262626 guibg=#eeeeee gui=NONE cterm=NONE
+  hi Cursor guifg=#eeeeee guibg=#262626 gui=NONE cterm=NONE
   hi None guifg=#262626 guibg=NONE gui=NONE cterm=NONE
   hi CursorLineNr guifg=#262626 guibg=#ecf5ff gui=NONE cterm=NONE
-  hi EndOfBuffer guifg=#ffffff guibg=#ffffff gui=NONE cterm=NONE
+  hi EndOfBuffer guifg=#eeeeee guibg=#eeeeee gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
-  hi MatchWord guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi MatchWord guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Signify guifg=#69a7fc guibg=NONE gui=NONE cterm=NONE
   hi Ignore guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Pmenu guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi PmenuSbar guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi PmenuSel guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi PmenuSel guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi PmenuThumb guifg=#e5e5e5 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi ErrorMsg guifg=#d12f1b guibg=NONE gui=NONE cterm=NONE
   hi ModeMsg guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
@@ -429,11 +429,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi ColorColumn guifg=NONE guibg=#f4f4f4 gui=NONE cterm=NONE
   hi CursorColumn guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
   hi CursorLine guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
-  hi QuickFixLine guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi QuickFixLine guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi StatusLine guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi StatusLineNC guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi VertSplit guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi WildMenu guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi WildMenu guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi IncSearch guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi Search guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi Visual guifg=NONE guibg=#b4d8fd gui=NONE cterm=NONE
@@ -442,7 +442,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi DiffDelete guifg=NONE guibg=#fef0f1 gui=NONE cterm=NONE
   hi DiffText guifg=NONE guibg=#fdfae6 gui=NONE cterm=NONE
   hi Comment guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
-  hi Error guifg=#ffffff guibg=#d12f1b gui=NONE cterm=NONE
+  hi Error guifg=#eeeeee guibg=#d12f1b gui=NONE cterm=NONE
   hi PreProc guifg=#78492a guibg=NONE gui=NONE cterm=NONE
   hi Special guifg=#23575c guibg=NONE gui=NONE cterm=NONE
   hi Statement guifg=#ad3da4 guibg=NONE gui=bold cterm=bold
@@ -706,7 +706,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if g:xcode_match_paren_style
     hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   else
-    hi MatchParen guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+    hi MatchParen guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   endif
   if g:xcode_dim_punctuation
     hi Delimiter guifg=#5c6873 guibg=NONE gui=NONE cterm=NONE
@@ -1390,7 +1390,7 @@ if s:t_Co >= 256
 endif
 
 " Background: dark
-" Color: base0        #292a30 ~
+" Color: base0        #000000 ~
 " Color: base1        #2f3037 ~
 " Color: base2        #393b44 ~
 " Color: base3        #414453 ~
@@ -1422,7 +1422,7 @@ endif
 " Term colors: base5      red  light_teal   orange
 " Term colors: light_blue pink light_purple base7
 " Background: light
-" Color: base0       #ffffff ~
+" Color: base0       #eeeeee ~
 " Color: base1       #f4f4f4 ~
 " Color: base2       #e5e5e5 ~
 " Color: base3       #cdcdcd ~

--- a/colors/xcodedark.vim
+++ b/colors/xcodedark.vim
@@ -60,11 +60,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   endif
   " support for folke/flash.nvim
   hi FlashLabel guifg=#1f1f24 guibg=#ff7ab2 gui=bold cterm=bold
-  hi Normal guifg=#dfdfe0 guibg=#292a30 gui=NONE cterm=NONE
-  hi Cursor guifg=#292a30 guibg=#dfdfe0 gui=NONE cterm=NONE
+  hi Normal guifg=#dfdfe0 guibg=#000000 gui=NONE cterm=NONE
+  hi Cursor guifg=#000000 guibg=#dfdfe0 gui=NONE cterm=NONE
   hi Empty guifg=#dfdfe0 guibg=NONE gui=NONE cterm=NONE
   hi CursorLineNr guifg=#dfdfe0 guibg=#2f3037 gui=NONE cterm=NONE
-  hi EndOfBuffer guifg=#292a30 guibg=#292a30 gui=NONE cterm=NONE
+  hi EndOfBuffer guifg=#000000 guibg=#000000 gui=NONE cterm=NONE
   hi FoldColumn guifg=#53606e guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#53606e guibg=#393b44 gui=NONE cterm=NONE
   hi LineNr guifg=#53606e guibg=NONE gui=NONE cterm=NONE
@@ -89,7 +89,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi StatusLineNC guifg=#7f8c98 guibg=#393b44 gui=NONE cterm=NONE
   hi VertSplit guifg=#393b44 guibg=#393b44 gui=NONE cterm=NONE
   hi WildMenu guifg=#dfdfe0 guibg=#0f5bca gui=NONE cterm=NONE
-  hi IncSearch guifg=#292a30 guibg=#fef937 gui=NONE cterm=NONE
+  hi IncSearch guifg=#000000 guibg=#fef937 gui=NONE cterm=NONE
   hi Search guifg=#dfdfe0 guibg=#414453 gui=NONE cterm=NONE
   hi Visual guifg=NONE guibg=#414453 gui=NONE cterm=NONE
   hi DiffAdd guifg=#acf2e4 guibg=#243330 gui=NONE cterm=NONE
@@ -97,7 +97,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi DiffDelete guifg=#ff8170 guibg=#3b2d2b gui=NONE cterm=NONE
   hi DiffText guifg=#ffa14f guibg=#382e27 gui=NONE cterm=NONE
   hi Comment guifg=#7f8c98 guibg=NONE gui=NONE cterm=NONE
-  hi Error guifg=#292a30 guibg=#ff8170 gui=NONE cterm=NONE
+  hi Error guifg=#000000 guibg=#ff8170 gui=NONE cterm=NONE
   hi PreProc guifg=#ffa14f guibg=NONE gui=NONE cterm=NONE
   hi Special guifg=#78c2b3 guibg=NONE gui=NONE cterm=NONE
   hi Statement guifg=#ff7ab2 guibg=NONE gui=bold cterm=bold
@@ -419,7 +419,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
     hi LibraryIdent guifg=#b281eb guibg=NONE gui=NONE cterm=NONE
   endif
   if g:xcodedark_match_paren_style
-    hi MatchParen guifg=#292a30 guibg=#fef937 gui=NONE cterm=NONE
+    hi MatchParen guifg=#000000 guibg=#fef937 gui=NONE cterm=NONE
   else
     hi MatchParen guifg=#dfdfe0 guibg=#0f5bca gui=NONE cterm=NONE
   endif
@@ -830,7 +830,7 @@ if s:t_Co == s:t_Co
   finish
 endif
 
-" Color: base0        #292a30 ~
+" Color: base0        #000000 ~
 " Color: base1        #2f3037 ~
 " Color: base2        #393b44 ~
 " Color: base3        #414453 ~

--- a/colors/xcodelight.vim
+++ b/colors/xcodelight.vim
@@ -67,7 +67,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi EndOfBuffer guifg=#e8e9ec guibg=#e8e9ec gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
-  hi LineNr guifg=#cdcdcd guibg=#e8e9ec gui=NONE cterm=NONE
+  hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi MatchWord guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE

--- a/colors/xcodelight.vim
+++ b/colors/xcodelight.vim
@@ -60,22 +60,22 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   endif
   " support for folke/flash.nvim
   hi FlashLabel guifg=#1f1f24 guibg=#ad3da4 gui=bold cterm=bold
-  hi Normal guifg=#262626 guibg=#eeeeee gui=NONE cterm=NONE
-  hi Cursor guifg=#eeeeee guibg=#262626 gui=NONE cterm=NONE
+  hi Normal guifg=#262626 guibg=#e8e9ec gui=NONE cterm=NONE
+  hi Cursor guifg=#e8e9ec guibg=#262626 gui=NONE cterm=NONE
   hi Empty guifg=#262626 guibg=NONE gui=NONE cterm=NONE
   hi CursorLineNr guifg=#262626 guibg=#ecf5ff gui=NONE cterm=NONE
-  hi EndOfBuffer guifg=#eeeeee guibg=#eeeeee gui=NONE cterm=NONE
+  hi EndOfBuffer guifg=#e8e9ec guibg=#e8e9ec gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
-  hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
+  hi LineNr guifg=#cdcdcd guibg=#e8e9ec gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
-  hi MatchWord guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi MatchWord guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Signify guifg=#69a7fc guibg=NONE gui=NONE cterm=NONE
   hi Ignore guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Pmenu guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi PmenuSbar guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi PmenuSel guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi PmenuSel guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi PmenuThumb guifg=#e5e5e5 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi ErrorMsg guifg=#d12f1b guibg=NONE gui=NONE cterm=NONE
   hi ModeMsg guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
@@ -85,11 +85,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi ColorColumn guifg=NONE guibg=#f4f4f4 gui=NONE cterm=NONE
   hi CursorColumn guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
   hi CursorLine guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
-  hi QuickFixLine guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi QuickFixLine guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi StatusLine guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi StatusLineNC guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi VertSplit guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi WildMenu guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+  hi WildMenu guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   hi IncSearch guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi Search guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi Visual guifg=NONE guibg=#b4d8fd gui=NONE cterm=NONE
@@ -98,7 +98,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi DiffDelete guifg=NONE guibg=#fef0f1 gui=NONE cterm=NONE
   hi DiffText guifg=NONE guibg=#fdfae6 gui=NONE cterm=NONE
   hi Comment guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
-  hi Error guifg=#eeeeee guibg=#d12f1b gui=NONE cterm=NONE
+  hi Error guifg=#e8e9ec guibg=#d12f1b gui=NONE cterm=NONE
   hi PreProc guifg=#78492a guibg=NONE gui=NONE cterm=NONE
   hi Special guifg=#23575c guibg=NONE gui=NONE cterm=NONE
   hi Statement guifg=#ad3da4 guibg=NONE gui=bold cterm=bold
@@ -255,7 +255,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi! link tsconstant Constant
   hi! link tsconstbuiltin Constant
   hi! link tsconstmacro Macro
-  hi tserror guifg=#262626 guibg=#eeeeee gui=bold cterm=bold
+  hi tserror guifg=#262626 guibg=#e8e9ec gui=bold cterm=bold
   hi! link tsexception Conditional
   hi! link tsfield Identifier
   hi! link tsfloat Float
@@ -422,7 +422,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if g:xcodelight_match_paren_style
     hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   else
-    hi MatchParen guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
+    hi MatchParen guifg=#e8e9ec guibg=#156adf gui=NONE cterm=NONE
   endif
   if g:xcodelight_dim_punctuation
     hi Delimiter guifg=#5c6873 guibg=NONE gui=NONE cterm=NONE
@@ -649,7 +649,7 @@ if s:t_Co >= 256
   hi! link tsconstant Constant
   hi! link tsconstbuiltin Constant
   hi! link tsconstmacro Macro
-  hi tserror guifg=#262626 guibg=#eeeeee gui=bold cterm=bold
+  hi tserror guifg=#262626 guibg=#e8e9ec gui=bold cterm=bold
   hi! link tsexception Conditional
   hi! link tsfield Identifier
   hi! link tsfloat Float
@@ -829,7 +829,7 @@ if s:t_Co >= 256
   finish
 endif
 
-" Color: base0       #eeeeee ~
+" Color: base0       #e8e9ec ~
 " Color: base1       #f4f4f4 ~
 " Color: base2       #e5e5e5 ~
 " Color: base3       #cdcdcd ~

--- a/colors/xcodelight.vim
+++ b/colors/xcodelight.vim
@@ -60,22 +60,22 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   endif
   " support for folke/flash.nvim
   hi FlashLabel guifg=#1f1f24 guibg=#ad3da4 gui=bold cterm=bold
-  hi Normal guifg=#262626 guibg=#ffffff gui=NONE cterm=NONE
-  hi Cursor guifg=#ffffff guibg=#262626 gui=NONE cterm=NONE
+  hi Normal guifg=#262626 guibg=#eeeeee gui=NONE cterm=NONE
+  hi Cursor guifg=#eeeeee guibg=#262626 gui=NONE cterm=NONE
   hi Empty guifg=#262626 guibg=NONE gui=NONE cterm=NONE
   hi CursorLineNr guifg=#262626 guibg=#ecf5ff gui=NONE cterm=NONE
-  hi EndOfBuffer guifg=#ffffff guibg=#ffffff gui=NONE cterm=NONE
+  hi EndOfBuffer guifg=#eeeeee guibg=#eeeeee gui=NONE cterm=NONE
   hi FoldColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Folded guifg=#8a99a6 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi LineNr guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
-  hi MatchWord guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi MatchWord guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi SignColumn guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Signify guifg=#69a7fc guibg=NONE gui=NONE cterm=NONE
   hi Ignore guifg=#cdcdcd guibg=NONE gui=NONE cterm=NONE
   hi Pmenu guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi PmenuSbar guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi PmenuSel guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi PmenuSel guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi PmenuThumb guifg=#e5e5e5 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi ErrorMsg guifg=#d12f1b guibg=NONE gui=NONE cterm=NONE
   hi ModeMsg guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
@@ -85,11 +85,11 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi ColorColumn guifg=NONE guibg=#f4f4f4 gui=NONE cterm=NONE
   hi CursorColumn guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
   hi CursorLine guifg=NONE guibg=#ecf5ff gui=NONE cterm=NONE
-  hi QuickFixLine guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi QuickFixLine guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi StatusLine guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi StatusLineNC guifg=#262626 guibg=#f4f4f4 gui=NONE cterm=NONE
   hi VertSplit guifg=#f4f4f4 guibg=#f4f4f4 gui=NONE cterm=NONE
-  hi WildMenu guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+  hi WildMenu guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   hi IncSearch guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   hi Search guifg=#262626 guibg=#e5e5e5 gui=NONE cterm=NONE
   hi Visual guifg=NONE guibg=#b4d8fd gui=NONE cterm=NONE
@@ -98,7 +98,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi DiffDelete guifg=NONE guibg=#fef0f1 gui=NONE cterm=NONE
   hi DiffText guifg=NONE guibg=#fdfae6 gui=NONE cterm=NONE
   hi Comment guifg=#8a99a6 guibg=NONE gui=NONE cterm=NONE
-  hi Error guifg=#ffffff guibg=#d12f1b gui=NONE cterm=NONE
+  hi Error guifg=#eeeeee guibg=#d12f1b gui=NONE cterm=NONE
   hi PreProc guifg=#78492a guibg=NONE gui=NONE cterm=NONE
   hi Special guifg=#23575c guibg=NONE gui=NONE cterm=NONE
   hi Statement guifg=#ad3da4 guibg=NONE gui=bold cterm=bold
@@ -255,7 +255,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi! link tsconstant Constant
   hi! link tsconstbuiltin Constant
   hi! link tsconstmacro Macro
-  hi tserror guifg=#262626 guibg=#ffffff gui=bold cterm=bold
+  hi tserror guifg=#262626 guibg=#eeeeee gui=bold cterm=bold
   hi! link tsexception Conditional
   hi! link tsfield Identifier
   hi! link tsfloat Float
@@ -422,7 +422,7 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   if g:xcodelight_match_paren_style
     hi MatchParen guifg=#262626 guibg=#fef869 gui=NONE cterm=NONE
   else
-    hi MatchParen guifg=#ffffff guibg=#156adf gui=NONE cterm=NONE
+    hi MatchParen guifg=#eeeeee guibg=#156adf gui=NONE cterm=NONE
   endif
   if g:xcodelight_dim_punctuation
     hi Delimiter guifg=#5c6873 guibg=NONE gui=NONE cterm=NONE
@@ -649,7 +649,7 @@ if s:t_Co >= 256
   hi! link tsconstant Constant
   hi! link tsconstbuiltin Constant
   hi! link tsconstmacro Macro
-  hi tserror guifg=#262626 guibg=#ffffff gui=bold cterm=bold
+  hi tserror guifg=#262626 guibg=#eeeeee gui=bold cterm=bold
   hi! link tsexception Conditional
   hi! link tsfield Identifier
   hi! link tsfloat Float
@@ -829,7 +829,7 @@ if s:t_Co >= 256
   finish
 endif
 
-" Color: base0       #ffffff ~
+" Color: base0       #eeeeee ~
 " Color: base1       #f4f4f4 ~
 " Color: base2       #e5e5e5 ~
 " Color: base3       #cdcdcd ~

--- a/templates/_xcodelight.colortemplate
+++ b/templates/_xcodelight.colortemplate
@@ -32,7 +32,7 @@ CursorLineNr   base6       light_aqua
 EndOfBuffer    base0       base0
 FoldColumn     base3       none
 Folded         base4       base2
-LineNr         base3       none
+LineNr         base3       base0
 MatchParen     base6       deep_yellow
 MatchWord      base0       deep_blue0
 SignColumn     base3       none

--- a/templates/_xcodelight.colortemplate
+++ b/templates/_xcodelight.colortemplate
@@ -32,7 +32,7 @@ CursorLineNr   base6       light_aqua
 EndOfBuffer    base0       base0
 FoldColumn     base3       none
 Folded         base4       base2
-LineNr         base3       base0
+LineNr         base3       none
 MatchParen     base6       deep_yellow
 MatchWord      base0       deep_blue0
 SignColumn     base3       none

--- a/templates/_xcodelight_colors.colortemplate
+++ b/templates/_xcodelight_colors.colortemplate
@@ -1,4 +1,4 @@
-Color: base0       #eeeeee ~
+Color: base0       #e8e9ec ~
 Color: base1       #f4f4f4 ~
 Color: base2       #e5e5e5 ~
 Color: base3       #cdcdcd ~


### PR DESCRIPTION
## Summary
- Refined the base0 background color to pure black (#000000) for dark themes (xcode.vim, xcodedark.vim) replacing previous dark gray
- Adjusted base0 background color to a slightly different off-white (#e8e9ec) for the light theme (xcodelight.vim), replacing the previous #eeeeee
- Updated cursor and related highlight groups to use the new background colors for better contrast and visual consistency
- Modified several highlight groups (e.g., Normal, Cursor, EndOfBuffer, IncSearch, Error, MatchParen, MatchWord, PmenuSel, QuickFixLine, WildMenu) to align with updated background colors

## Changes

### colors/xcode.vim
- Set Normal and Cursor highlight foreground/background to #dfdfe0/#000000 and #000000/#dfdfe0 respectively
- Updated EndOfBuffer, IncSearch, Error, MatchParen, and other groups to use #000000 background for dark mode
- For light mode, changed Normal background to #e8e9ec and adjusted related highlights accordingly
- Updated base0 color comment to #000000 for dark and #e8e9ec for light

### colors/xcodedark.vim
- Changed Normal, Cursor, EndOfBuffer, IncSearch, Error, MatchParen highlights to use #000000 background
- Updated base0 color comment to #000000

### colors/xcodelight.vim
- Changed Normal, Cursor, EndOfBuffer, MatchWord, PmenuSel, QuickFixLine, WildMenu, Error, and tserror highlights to use #e8e9ec background
- Updated base0 color comment to #e8e9ec
- Adjusted template files to reflect new base0 color #e8e9ec

## Test plan
- Verified color changes in Vim with termguicolors enabled
- Checked visual contrast and readability for both dark and light themes
- Ensured no regressions in other highlight groups
- Confirmed compatibility with folke/flash.nvim plugin highlights

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/58e4b579-31a0-4bc4-908e-6ff80fb4ce32
